### PR TITLE
Harden store integration with endpoint fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ management, and an end-to-end checkout flow.
 
 - **Live WooCommerce integration** that fetches categories and products from
   `https://www.valleyfarmsecrets.com/store`, automatically probing both root and
-  `/store` REST API paths with an offline fallback catalogue defined in
-  `lib/data/store_data.dart`.
+  `/store` REST API paths (including the versioned `wc/store/v1` routes) with an
+  offline fallback catalogue defined in `lib/data/store_data.dart`.
 - **Responsive layout** that presents sidebar filters on wide screens and a
   drawer-based experience on smaller devices.
 - **Special offers carousel** that highlights products currently on promotion.
@@ -56,6 +56,18 @@ lib/
   Unsplash so the repository stays free of binary assets.
 - The Material 3 theme uses the Valley Farm colour palette defined in
   `lib/constants.dart`.
+
+### Image requirements
+
+| Purpose | Path / URL | Size (px) | Notes |
+| --- | --- | --- | --- |
+| Android launcher icon (mdpi) | `android/app/src/main/res/mipmap-mdpi/ic_launcher.png` | 48 × 48 | Default Flutter launcher asset |
+| Android launcher icon (hdpi) | `android/app/src/main/res/mipmap-hdpi/ic_launcher.png` | 72 × 72 | Default Flutter launcher asset |
+| Android launcher icon (xhdpi) | `android/app/src/main/res/mipmap-xhdpi/ic_launcher.png` | 96 × 96 | Default Flutter launcher asset |
+| Android launcher icon (xxhdpi) | `android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png` | 144 × 144 | Default Flutter launcher asset |
+| Android launcher icon (xxxhdpi) | `android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png` | 192 × 192 | Default Flutter launcher asset |
+| Product placeholder image | `https://images.unsplash.com/photo-1484981137413-6f0d4f3b3326?auto=format&fit=crop&w=800&q=80` | 800 × 533 (cropped) | Used when WooCommerce products do not expose their own image |
+| Web manifest icon slots | `web/manifest.json` | 192 × 192, 512 × 512 | Declare images but the files need to be supplied before publishing |
 
 ## Tests & linting
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ management, and an end-to-end checkout flow.
 
 ## Features
 
-- **Seeded catalogue** with the Valley Farm Secrets categories, subcategories,
-  and products defined in `lib/data/store_data.dart`.
+- **Live WooCommerce integration** that fetches categories and products from
+  `https://www.valleyfarmsecrets.com/store`, automatically probing both root and
+  `/store` REST API paths with an offline fallback catalogue defined in
+  `lib/data/store_data.dart`.
 - **Responsive layout** that presents sidebar filters on wide screens and a
   drawer-based experience on smaller devices.
 - **Special offers carousel** that highlights products currently on promotion.
@@ -30,10 +32,10 @@ flutter pub get
 flutter run
 ```
 
-> **Note:** The checkout flow sends a demo POST request to
-> `https://example.com/api/orders`. Update `ordersEndpoint` in
-> `lib/constants.dart` to point to a real backend before shipping to
-> production.
+> **Note:** The checkout flow posts to the Valley Farm Secrets WooCommerce
+> checkout endpoint configured in `lib/constants.dart`. Update
+> `storeCheckoutEndpoints` if your deployment requires a different authenticated
+> endpoint or additional fallbacks.
 
 ## Project structure
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -4,19 +4,24 @@ const double bikerDeliveryFee = 5.0;
 
 /// Candidate base URLs for the live Valley Farm Secrets WooCommerce Store API.
 ///
-/// The store is hosted under `/store`, but the underlying WordPress REST API can
-/// be exposed either from the root domain or the `/store` subdirectory depending
-/// on the server configuration. Trying both gives the app a better chance of
-/// reaching the live catalogue without requiring a code change.
+/// The WordPress installation serves the REST API both from the root domain and
+/// the `/store` subdirectory. Additionally, newer WooCommerce deployments expose
+/// the versioned `wc/store/v1` endpoints while older builds still answer under
+/// `wc/store`. Listing each permutation allows the app to seamlessly fall back
+/// without additional configuration when the server is upgraded or moved.
 const List<String> storeApiBaseUrls = <String>[
+  'https://www.valleyfarmsecrets.com/store/wp-json/wc/store/v1',
   'https://www.valleyfarmsecrets.com/store/wp-json/wc/store',
+  'https://www.valleyfarmsecrets.com/wp-json/wc/store/v1',
   'https://www.valleyfarmsecrets.com/wp-json/wc/store',
 ];
 
 /// Checkout endpoints derived from [storeApiBaseUrls]. The first responsive
 /// endpoint will be used when attempting to submit an order.
 const List<String> storeCheckoutEndpoints = <String>[
+  'https://www.valleyfarmsecrets.com/store/wp-json/wc/store/v1/checkout',
   'https://www.valleyfarmsecrets.com/store/wp-json/wc/store/checkout',
+  'https://www.valleyfarmsecrets.com/wp-json/wc/store/v1/checkout',
   'https://www.valleyfarmsecrets.com/wp-json/wc/store/checkout',
 ];
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,7 +1,28 @@
 import 'package:flutter/material.dart';
 
 const double bikerDeliveryFee = 5.0;
-const String ordersEndpoint = 'https://example.com/api/orders';
+
+/// Candidate base URLs for the live Valley Farm Secrets WooCommerce Store API.
+///
+/// The store is hosted under `/store`, but the underlying WordPress REST API can
+/// be exposed either from the root domain or the `/store` subdirectory depending
+/// on the server configuration. Trying both gives the app a better chance of
+/// reaching the live catalogue without requiring a code change.
+const List<String> storeApiBaseUrls = <String>[
+  'https://www.valleyfarmsecrets.com/store/wp-json/wc/store',
+  'https://www.valleyfarmsecrets.com/wp-json/wc/store',
+];
+
+/// Checkout endpoints derived from [storeApiBaseUrls]. The first responsive
+/// endpoint will be used when attempting to submit an order.
+const List<String> storeCheckoutEndpoints = <String>[
+  'https://www.valleyfarmsecrets.com/store/wp-json/wc/store/checkout',
+  'https://www.valleyfarmsecrets.com/wp-json/wc/store/checkout',
+];
+
+/// Fallback image used when a product does not expose a dedicated thumbnail.
+const String placeholderImageUrl =
+    'https://images.unsplash.com/photo-1484981137413-6f0d4f3b3326?auto=format&fit=crop&w=800&q=80';
 
 const Color primaryGreen = Color(0xFF5B8C51);
 const Color accentGold = Color(0xFFE0B341);

--- a/lib/data/store_data.dart
+++ b/lib/data/store_data.dart
@@ -5,9 +5,6 @@ import '../models/category.dart';
 import '../models/product.dart';
 import '../models/sub_category.dart';
 
-const String placeholderImageUrl =
-    'https://images.unsplash.com/photo-1484981137413-6f0d4f3b3326?auto=format&fit=crop&w=800&q=80';
-
 final List<Category> storeCategories = <Category>[
   Category(
     id: 'fresh-produce',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'constants.dart';
 import 'providers/cart_provider.dart';
+import 'providers/store_provider.dart';
 import 'screens/store_screen.dart';
 
 void main() {
@@ -18,8 +19,11 @@ class ValleyFarmApp extends StatelessWidget {
       secondary: accentGold,
     );
 
-    return ChangeNotifierProvider<CartProvider>(
-      create: (_) => CartProvider(),
+    return MultiProvider(
+      providers: <ChangeNotifierProvider<dynamic>>[
+        ChangeNotifierProvider<CartProvider>(create: (_) => CartProvider()),
+        ChangeNotifierProvider<StoreProvider>(create: (_) => StoreProvider()),
+      ],
       child: MaterialApp(
         title: 'Valley Farm Secrets Store',
         debugShowCheckedModeBanner: false,

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -10,6 +10,10 @@ class Product {
     this.oldPrice,
     this.description,
     this.onSpecial = false,
+    this.currencyCode = 'USD',
+    this.currencySymbol = 'US\$',
+    this.currencySuffix = '',
+    this.permalink,
   });
 
   final String id;
@@ -22,6 +26,36 @@ class Product {
   final bool onSpecial;
   final String imageUrl;
   final String? description;
+  final String currencyCode;
+  final String currencySymbol;
+  final String currencySuffix;
+  final String? permalink;
 
   double get savings => oldPrice != null ? oldPrice! - price : 0;
+
+  String get currencyLabel {
+    if (currencySymbol.trim().isNotEmpty) {
+      return currencySymbol.trim();
+    }
+    if (currencySuffix.trim().isNotEmpty) {
+      return currencySuffix.trim();
+    }
+    return currencyCode;
+  }
+
+  String formatPrice(double amount) {
+    final String formatted = amount.toStringAsFixed(2);
+    final String symbol = currencySymbol.trim();
+    final String suffix = currencySuffix.trim();
+    if (symbol.isNotEmpty && suffix.isNotEmpty) {
+      return '$symbol $formatted $suffix';
+    }
+    if (symbol.isNotEmpty) {
+      return '$symbol $formatted';
+    }
+    if (suffix.isNotEmpty) {
+      return '$formatted $suffix';
+    }
+    return '${currencyCode.toUpperCase()} $formatted';
+  }
 }

--- a/lib/providers/cart_provider.dart
+++ b/lib/providers/cart_provider.dart
@@ -19,6 +19,35 @@ class CartProvider extends ChangeNotifier {
 
   bool get isEmpty => _items.isEmpty;
 
+  String get currencyCode =>
+      _items.isNotEmpty ? _items.values.first.product.currencyCode : 'USD';
+
+  String get currencySymbol =>
+      _items.isNotEmpty ? _items.values.first.product.currencySymbol : 'US\$';
+
+  String get currencySuffix =>
+      _items.isNotEmpty ? _items.values.first.product.currencySuffix : '';
+
+  String get currencyLabel {
+    final String symbol = currencySymbol.trim();
+    if (symbol.isNotEmpty) {
+      return symbol;
+    }
+    final String suffix = currencySuffix.trim();
+    if (suffix.isNotEmpty) {
+      return suffix;
+    }
+    return currencyCode;
+  }
+
+  String formatAmount(double value) {
+    if (_items.isEmpty) {
+      final String label = currencyLabel;
+      return '$label ${value.toStringAsFixed(2)}';
+    }
+    return _items.values.first.product.formatPrice(value);
+  }
+
   void addItem(Product product) {
     final CartItem? existing = _items[product.id];
     if (existing != null) {

--- a/lib/providers/store_provider.dart
+++ b/lib/providers/store_provider.dart
@@ -19,6 +19,7 @@ class StoreProvider extends ChangeNotifier {
   String _currencyCode = 'USD';
   String _currencySymbol = 'US\$';
   String _currencySuffix = '';
+  Uri? _activeEndpoint;
 
   List<Category> get categories => List<Category>.unmodifiable(_categories);
   List<Product> get products => List<Product>.unmodifiable(_products);
@@ -28,6 +29,7 @@ class StoreProvider extends ChangeNotifier {
   String get currencyCode => _currencyCode;
   String get currencySymbol => _currencySymbol;
   String get currencySuffix => _currencySuffix;
+  Uri? get activeEndpoint => _activeEndpoint;
   String get currencyLabel {
     if (_currencySymbol.trim().isNotEmpty) {
       return _currencySymbol.trim();
@@ -70,6 +72,8 @@ class StoreProvider extends ChangeNotifier {
       _currencySymbol = catalog.currencySymbol;
       _currencySuffix = catalog.currencySuffix;
       _statusMessage = null;
+      _activeEndpoint = catalog.source;
+      debugPrint('StoreProvider loaded live catalogue from ${catalog.source}');
     } on StoreServiceException catch (error, stackTrace) {
       debugPrint('StoreProvider failed to load catalog: $error');
       debugPrintStack(stackTrace: stackTrace);
@@ -100,5 +104,6 @@ class StoreProvider extends ChangeNotifier {
     _currencyCode = 'USD';
     _currencySymbol = 'US\$';
     _currencySuffix = '';
+    _activeEndpoint = null;
   }
 }

--- a/lib/providers/store_provider.dart
+++ b/lib/providers/store_provider.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/store_data.dart';
+import '../models/category.dart';
+import '../models/product.dart';
+import '../services/store_service.dart';
+
+class StoreProvider extends ChangeNotifier {
+  StoreProvider({StoreService? service}) : _service = service ?? StoreService();
+
+  final StoreService _service;
+
+  final List<Category> _categories = <Category>[];
+  final List<Product> _products = <Product>[];
+
+  bool _isLoading = false;
+  bool _hasAttemptedInitialLoad = false;
+  String? _statusMessage;
+  String _currencyCode = 'USD';
+  String _currencySymbol = 'US\$';
+  String _currencySuffix = '';
+
+  List<Category> get categories => List<Category>.unmodifiable(_categories);
+  List<Product> get products => List<Product>.unmodifiable(_products);
+
+  bool get isLoading => _isLoading;
+  String? get statusMessage => _statusMessage;
+  String get currencyCode => _currencyCode;
+  String get currencySymbol => _currencySymbol;
+  String get currencySuffix => _currencySuffix;
+  String get currencyLabel {
+    if (_currencySymbol.trim().isNotEmpty) {
+      return _currencySymbol.trim();
+    }
+    if (_currencySuffix.trim().isNotEmpty) {
+      return _currencySuffix.trim();
+    }
+    return _currencyCode;
+  }
+
+  Future<void> ensureLoaded() async {
+    if (_hasAttemptedInitialLoad || _isLoading) {
+      return;
+    }
+    await load();
+  }
+
+  Future<void> load({bool forceRefresh = false}) async {
+    if (_isLoading) {
+      return;
+    }
+    if (!forceRefresh && _hasAttemptedInitialLoad) {
+      return;
+    }
+    _isLoading = true;
+    _hasAttemptedInitialLoad = true;
+    notifyListeners();
+
+    try {
+      final StoreCatalog catalog = await _service.fetchCatalog();
+      final List<Category> sortedCategories = List<Category>.from(catalog.categories)
+        ..sort((Category a, Category b) => a.name.compareTo(b.name));
+      _categories
+        ..clear()
+        ..addAll(sortedCategories);
+      _products
+        ..clear()
+        ..addAll(catalog.products);
+      _currencyCode = catalog.currencyCode;
+      _currencySymbol = catalog.currencySymbol;
+      _currencySuffix = catalog.currencySuffix;
+      _statusMessage = null;
+    } on StoreServiceException catch (error, stackTrace) {
+      debugPrint('StoreProvider failed to load catalog: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      _statusMessage =
+          'Using offline catalogue. ${error.displayMessage}';
+      _applyOfflineFallback();
+    } catch (Object error, StackTrace stackTrace) {
+      debugPrint('StoreProvider hit an unexpected error: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      _statusMessage =
+          'Unable to load the live Valley Farm Secrets catalogue. Showing offline data.';
+      _applyOfflineFallback();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> reload() => load(forceRefresh: true);
+
+  void _applyOfflineFallback() {
+    _categories
+      ..clear()
+      ..addAll(storeCategories);
+    _products
+      ..clear()
+      ..addAll(storeProducts);
+    _currencyCode = 'USD';
+    _currencySymbol = 'US\$';
+    _currencySuffix = '';
+  }
+}

--- a/lib/services/order_service.dart
+++ b/lib/services/order_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -7,9 +8,19 @@ import '../constants.dart';
 import '../models/cart_item.dart';
 
 class OrderService {
-  OrderService({http.Client? client}) : _client = client ?? http.Client();
+  OrderService({
+    http.Client? client,
+    List<String> endpoints = storeCheckoutEndpoints,
+    this.requestTimeout = const Duration(seconds: 12),
+  })  : _client = client ?? http.Client(),
+        _endpoints = endpoints
+            .where((String url) => url.trim().isNotEmpty)
+            .map(Uri.parse)
+            .toList(growable: false);
 
   final http.Client _client;
+  final List<Uri> _endpoints;
+  final Duration requestTimeout;
 
   Future<bool> submitOrder({
     required List<CartItem> items,
@@ -18,6 +29,12 @@ class OrderService {
     double deliveryFee = 0,
   }) async {
     final double total = subtotal + deliveryFee;
+    final String currencyCode =
+        items.isNotEmpty ? items.first.product.currencyCode : 'USD';
+    final String currencySymbol =
+        items.isNotEmpty ? items.first.product.currencySymbol : 'US\$';
+    final String currencySuffix =
+        items.isNotEmpty ? items.first.product.currencySuffix : '';
     final Map<String, dynamic> payload = <String, dynamic>{
       'items': items
           .map((CartItem item) => <String, dynamic>{
@@ -26,25 +43,52 @@ class OrderService {
                 'unitPrice': item.product.price,
                 'quantity': item.quantity,
                 'subtotal': item.subtotal,
+                'permalink': item.product.permalink,
+                'imageUrl': item.product.imageUrl,
               })
           .toList(),
       'customer': customer,
       'subtotal': subtotal,
       'deliveryFee': deliveryFee,
       'total': total,
+      'currency': <String, String>{
+        'code': currencyCode,
+        'symbol': currencySymbol,
+        'suffix': currencySuffix,
+      },
     };
 
-    try {
-      final http.Response response = await _client.post(
-        Uri.parse(ordersEndpoint),
-        headers: const <String, String>{'Content-Type': 'application/json'},
-        body: jsonEncode(payload),
-      );
-      return response.statusCode >= 200 && response.statusCode < 300;
-    } catch (error, stackTrace) {
-      debugPrint('Order submission failed: $error');
-      debugPrintStack(stackTrace: stackTrace);
+    if (_endpoints.isEmpty) {
+      debugPrint('Order submission failed: no checkout endpoints configured.');
       return false;
     }
+
+    final List<String> failures = <String>[];
+
+    for (final Uri endpoint in _endpoints) {
+      try {
+        final http.Response response = await _client
+            .post(
+              endpoint,
+              headers: const <String, String>{
+                'Content-Type': 'application/json',
+              },
+              body: jsonEncode(payload),
+            )
+            .timeout(requestTimeout);
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+          return true;
+        }
+        failures.add('HTTP ${response.statusCode} from ${endpoint.toString()}');
+      } on TimeoutException catch (_) {
+        failures.add('Timeout contacting ${endpoint.toString()}');
+      } catch (Object error, StackTrace stackTrace) {
+        failures.add('Error contacting ${endpoint.toString()}: $error');
+        debugPrintStack(stackTrace: stackTrace);
+      }
+    }
+
+    debugPrint('Order submission failed: ${failures.join('; ')}');
+    return false;
   }
 }

--- a/lib/services/order_service.dart
+++ b/lib/services/order_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -13,10 +14,14 @@ class OrderService {
     List<String> endpoints = storeCheckoutEndpoints,
     this.requestTimeout = const Duration(seconds: 12),
   })  : _client = client ?? http.Client(),
-        _endpoints = endpoints
-            .where((String url) => url.trim().isNotEmpty)
-            .map(Uri.parse)
-            .toList(growable: false);
+        _endpoints = List<Uri>.unmodifiable(
+          LinkedHashSet<Uri>.from(
+            endpoints
+                .map((String url) => Uri.tryParse(url.trim()))
+                .whereType<Uri>()
+                .where((Uri uri) => uri.hasScheme && uri.host.isNotEmpty),
+          ),
+        );
 
   final http.Client _client;
   final List<Uri> _endpoints;

--- a/lib/services/store_service.dart
+++ b/lib/services/store_service.dart
@@ -1,0 +1,503 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:http/http.dart' as http;
+
+import '../constants.dart';
+import '../models/category.dart';
+import '../models/product.dart';
+import '../models/sub_category.dart';
+
+class StoreCatalog {
+  const StoreCatalog({
+    required this.categories,
+    required this.products,
+    required this.currencyCode,
+    required this.currencySymbol,
+    required this.currencySuffix,
+  });
+
+  final List<Category> categories;
+  final List<Product> products;
+  final String currencyCode;
+  final String currencySymbol;
+  final String currencySuffix;
+}
+
+class StoreService {
+  StoreService({
+    http.Client? client,
+    List<String> baseUrls = storeApiBaseUrls,
+    this.requestTimeout = const Duration(seconds: 12),
+  })  : _client = client ?? http.Client(),
+        _baseUrls = baseUrls
+            .where((String url) => url.trim().isNotEmpty)
+            .toList(growable: false);
+
+  final http.Client _client;
+  final List<String> _baseUrls;
+  final Duration requestTimeout;
+
+  static const int _pageSize = 100;
+
+  Future<StoreCatalog> fetchCatalog() async {
+    if (_baseUrls.isEmpty) {
+      throw StoreServiceException(
+        message: 'No Valley Farm Secrets store API endpoints were configured.',
+      );
+    }
+
+    StoreServiceException? lastException;
+    for (final String baseUrl in _baseUrls) {
+      try {
+        final List<Category> categories = await _fetchCategories(baseUrl);
+        final _ProductResponse productResponse =
+            await _fetchProducts(baseUrl, categories: categories);
+        if (productResponse.products.isEmpty) {
+          throw StoreServiceException(
+            message: 'No products returned from the store API.',
+          );
+        }
+        return StoreCatalog(
+          categories: categories,
+          products: productResponse.products,
+          currencyCode: productResponse.currencyCode,
+          currencySymbol: productResponse.currencySymbol,
+          currencySuffix: productResponse.currencySuffix,
+        );
+      } on StoreServiceException catch (error) {
+        lastException = error;
+        continue;
+      } catch (Object error) {
+        lastException = StoreServiceException(
+          message: 'Unexpected error loading store data: $error',
+          cause: error,
+        );
+        continue;
+      }
+    }
+
+    throw lastException ??
+        StoreServiceException(
+          message: 'Unable to load catalogue from Valley Farm Secrets.',
+        );
+  }
+
+  Future<List<Category>> _fetchCategories(String baseUrl) async {
+    final Uri uri =
+        Uri.parse('$baseUrl/products/categories?per_page=$_pageSize');
+    final http.Response response = await _get(uri);
+    if (!_isSuccess(response.statusCode)) {
+      throw StoreServiceException(
+        message: 'Failed to load categories',
+        uri: uri,
+        statusCode: response.statusCode,
+      );
+    }
+
+    final List<dynamic> decoded = _decodeJsonList(response.body, uri);
+    final Map<int, Map<String, dynamic>> raw = <int, Map<String, dynamic>>{};
+    final Map<int, List<SubCategory>> children = <int, List<SubCategory>>{};
+
+    for (final dynamic entry in decoded) {
+      if (entry is! Map<String, dynamic>) {
+        continue;
+      }
+      final int? id = _asInt(entry['id']);
+      if (id == null) {
+        continue;
+      }
+      raw[id] = entry;
+      final int parentId = _asInt(entry['parent']) ?? 0;
+      if (parentId != 0) {
+        final String name = (entry['name'] as String? ?? '').trim();
+        children.putIfAbsent(parentId, () => <SubCategory>[]).add(
+              SubCategory(
+                id: id.toString(),
+                name: name.isEmpty ? 'Category $id' : name,
+              ),
+            );
+      }
+    }
+
+    final List<Category> categories = <Category>[];
+    for (final MapEntry<int, Map<String, dynamic>> entry in raw.entries) {
+      final int parentId = _asInt(entry.value['parent']) ?? 0;
+      if (parentId != 0 && raw.containsKey(parentId)) {
+        continue;
+      }
+      final int id = entry.key;
+      final String name = (entry.value['name'] as String? ?? '').trim();
+      final String description =
+          _cleanHtml(entry.value['description'] as String?);
+      categories.add(
+        Category(
+          id: id.toString(),
+          name: name.isEmpty ? 'Category $id' : name,
+          description: description,
+          subCategories:
+              List<SubCategory>.unmodifiable(children[id] ?? <SubCategory>[]),
+        ),
+      );
+    }
+
+    categories.sort((Category a, Category b) => a.name.compareTo(b.name));
+    return categories;
+  }
+
+  Future<_ProductResponse> _fetchProducts(
+    String baseUrl, {
+    required List<Category> categories,
+  }) async {
+    final Map<String, Category> categoryById = <String, Category>{
+      for (final Category category in categories) category.id: category,
+    };
+    final List<Product> products = <Product>[];
+    String currencyCode = 'USD';
+    String currencySymbol = 'US\$';
+    String currencySuffix = '';
+
+    int page = 1;
+    while (true) {
+      final Uri uri =
+          Uri.parse('$baseUrl/products?per_page=$_pageSize&page=$page');
+      final http.Response response = await _get(uri);
+      if (!_isSuccess(response.statusCode)) {
+        throw StoreServiceException(
+          message: 'Failed to load products',
+          uri: uri,
+          statusCode: response.statusCode,
+        );
+      }
+      final List<dynamic> decoded = _decodeJsonList(response.body, uri);
+      if (decoded.isEmpty) {
+        break;
+      }
+      for (final dynamic entry in decoded) {
+        if (entry is! Map<String, dynamic>) {
+          continue;
+        }
+        final Product? product = _mapProduct(
+          entry,
+          categoryById: categoryById,
+          categories: categories,
+        );
+        if (product != null) {
+          products.add(product);
+          currencyCode = product.currencyCode;
+          currencySymbol = product.currencySymbol;
+          currencySuffix = product.currencySuffix;
+        }
+      }
+      if (decoded.length < _pageSize) {
+        break;
+      }
+      page += 1;
+    }
+
+    return _ProductResponse(
+      products: products,
+      currencyCode: currencyCode,
+      currencySymbol: currencySymbol,
+      currencySuffix: currencySuffix,
+    );
+  }
+
+  Future<http.Response> _get(Uri uri) async {
+    try {
+      return await _client.get(uri).timeout(requestTimeout);
+    } on TimeoutException catch (error) {
+      throw StoreServiceException(
+        message:
+            'Request to ${uri.host} timed out after ${requestTimeout.inSeconds}s.',
+        uri: uri,
+        cause: error,
+      );
+    } on http.ClientException catch (error) {
+      throw StoreServiceException(
+        message: 'Network error contacting the Valley Farm Secrets store.',
+        uri: uri,
+        cause: error,
+      );
+    } catch (Object error) {
+      throw StoreServiceException(
+        message: 'Network error contacting the Valley Farm Secrets store.',
+        uri: uri,
+        cause: error,
+      );
+    }
+  }
+
+  List<dynamic> _decodeJsonList(String body, Uri uri) {
+    try {
+      final dynamic decoded = jsonDecode(body);
+      if (decoded is List<dynamic>) {
+        return decoded;
+      }
+    } on FormatException catch (error) {
+      throw StoreServiceException(
+        message: 'Invalid JSON response from the store API.',
+        uri: uri,
+        cause: error,
+      );
+    }
+    throw StoreServiceException(
+      message: 'Unexpected response structure from the store API.',
+      uri: uri,
+    );
+  }
+
+  Product? _mapProduct(
+    Map<String, dynamic> json, {
+    required Map<String, Category> categoryById,
+    required List<Category> categories,
+  }) {
+    final dynamic idValue = json['id'];
+    if (idValue == null) {
+      return null;
+    }
+    final String id = idValue.toString();
+    final String name = (json['name'] as String? ?? '').trim();
+    if (name.isEmpty) {
+      return null;
+    }
+
+    final Map<String, dynamic> prices =
+        (json['prices'] as Map<String, dynamic>?) ?? <String, dynamic>{};
+    final int minorUnits = _asInt(prices['currency_minor_unit']) ?? 2;
+    final double divisor = math.pow(10, minorUnits).toDouble();
+
+    double? parsePrice(dynamic value) {
+      if (value == null) {
+        return null;
+      }
+      final String normalised = value.toString().replaceAll(',', '');
+      if (normalised.isEmpty) {
+        return null;
+      }
+      final double? parsed = double.tryParse(normalised);
+      if (parsed == null) {
+        return null;
+      }
+      if (normalised.contains('.')) {
+        return parsed;
+      }
+      return parsed / divisor;
+    }
+
+    double price = parsePrice(prices['price']) ?? 0;
+    final double? regularPrice = parsePrice(prices['regular_price']);
+    final double? salePrice = parsePrice(prices['sale_price']);
+
+    bool onSpecial = false;
+    double? oldPrice;
+    if (salePrice != null && salePrice > 0 && (regularPrice ?? price) > salePrice) {
+      oldPrice = regularPrice ?? price;
+      price = salePrice;
+      onSpecial = true;
+    } else if (regularPrice != null && regularPrice > price) {
+      oldPrice = regularPrice;
+    }
+
+    final String currencyCode =
+        (prices['currency_code'] as String? ?? 'USD').toUpperCase();
+    final String currencySymbol =
+        (prices['currency_prefix'] as String? ?? prices['currency_symbol'] as String? ?? '')
+            .toString();
+    final String currencySuffix =
+        (prices['currency_suffix'] as String? ?? '').toString();
+
+    final List<Map<String, dynamic>> categoryEntries =
+        (json['categories'] as List<dynamic>? ?? <dynamic>[])
+            .whereType<Map<String, dynamic>>()
+            .toList();
+
+    String categoryId = 'uncategorized';
+    String? subCategoryId;
+    if (categoryEntries.isNotEmpty) {
+      Map<String, dynamic>? topLevel;
+      for (final Map<String, dynamic> entry in categoryEntries) {
+        final int parentId = _asInt(entry['parent']) ?? 0;
+        if (parentId == 0) {
+          topLevel = entry;
+          break;
+        }
+      }
+      topLevel ??= categoryEntries.first;
+      final int topLevelId = _asInt(topLevel['id']) ?? 0;
+      final int parentId = _asInt(topLevel['parent']) ?? 0;
+      if (parentId != 0) {
+        categoryId = parentId.toString();
+        subCategoryId = topLevelId.toString();
+        _ensureCategoryExists(
+          categoryId: categoryId,
+          source: categoryEntries.firstWhere(
+            (Map<String, dynamic> entry) => (_asInt(entry['id']) ?? 0) == parentId,
+            orElse: () => topLevel!,
+          ),
+          categoryById: categoryById,
+          categories: categories,
+        );
+      } else {
+        categoryId = topLevelId.toString();
+        for (final Map<String, dynamic> entry in categoryEntries) {
+          final int potentialParent = _asInt(entry['parent']) ?? 0;
+          if (potentialParent == topLevelId) {
+            subCategoryId = (_asInt(entry['id']) ?? 0).toString();
+            break;
+          }
+        }
+        _ensureCategoryExists(
+          categoryId: categoryId,
+          source: topLevel!,
+          categoryById: categoryById,
+          categories: categories,
+        );
+      }
+    } else {
+      _ensureCategoryExists(
+        categoryId: categoryId,
+        source: <String, dynamic>{'name': 'Uncategorized'},
+        categoryById: categoryById,
+        categories: categories,
+      );
+    }
+
+    final List<Map<String, dynamic>> images =
+        (json['images'] as List<dynamic>? ?? <dynamic>[])
+            .whereType<Map<String, dynamic>>()
+            .toList();
+    String imageUrl = placeholderImageUrl;
+    if (images.isNotEmpty) {
+      final String candidate = (images.first['src'] as String? ?? '').trim();
+      if (candidate.isNotEmpty) {
+        imageUrl = candidate;
+      }
+    }
+
+    final String shortDescription =
+        _cleanHtml(json['short_description'] as String?);
+    final String description = shortDescription.isNotEmpty
+        ? shortDescription
+        : _cleanHtml(json['description'] as String?);
+
+    return Product(
+      id: id,
+      name: name,
+      categoryId: categoryId,
+      subCategoryId: subCategoryId,
+      price: price,
+      oldPrice: oldPrice,
+      unit: 'Per item',
+      imageUrl: imageUrl,
+      description: description.isNotEmpty ? description : null,
+      onSpecial: onSpecial,
+      currencyCode: currencyCode,
+      currencySymbol: currencySymbol,
+      currencySuffix: currencySuffix,
+      permalink: (json['permalink'] as String?)?.trim(),
+    );
+  }
+
+  void _ensureCategoryExists({
+    required String categoryId,
+    required Map<String, dynamic> source,
+    required Map<String, Category> categoryById,
+    required List<Category> categories,
+  }) {
+    if (categoryById.containsKey(categoryId)) {
+      return;
+    }
+    final String name = (source['name'] as String? ?? '').trim();
+    final String description = _cleanHtml(source['description'] as String?);
+    final Category category = Category(
+      id: categoryId,
+      name: name.isEmpty ? 'Category $categoryId' : name,
+      description: description,
+    );
+    categories.add(category);
+    categoryById[categoryId] = category;
+  }
+
+  bool _isSuccess(int statusCode) => statusCode >= 200 && statusCode < 300;
+
+  int? _asInt(dynamic value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is double) {
+      return value.round();
+    }
+    if (value is String) {
+      return int.tryParse(value);
+    }
+    return null;
+  }
+
+  String _cleanHtml(String? value) {
+    if (value == null) {
+      return '';
+    }
+    final String withoutTags = value.replaceAll(RegExp(r'<[^>]*>'), ' ');
+    return withoutTags
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&amp;', '&')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+  }
+}
+
+class _ProductResponse {
+  const _ProductResponse({
+    required this.products,
+    required this.currencyCode,
+    required this.currencySymbol,
+    required this.currencySuffix,
+  });
+
+  final List<Product> products;
+  final String currencyCode;
+  final String currencySymbol;
+  final String currencySuffix;
+}
+
+class StoreServiceException implements Exception {
+  StoreServiceException({
+    required this.message,
+    this.uri,
+    this.statusCode,
+    this.cause,
+  });
+
+  final String message;
+  final Uri? uri;
+  final int? statusCode;
+  final Object? cause;
+
+  String get displayMessage {
+    final StringBuffer buffer = StringBuffer(message);
+    if (statusCode != null) {
+      buffer.write(' (HTTP $statusCode)');
+    }
+    if (uri != null) {
+      buffer.write(' – ${uri!.origin}${uri!.path}');
+    }
+    return buffer.toString();
+  }
+
+  @override
+  String toString() {
+    final StringBuffer buffer = StringBuffer('StoreServiceException: $message');
+    if (statusCode != null) {
+      buffer.write(' (HTTP $statusCode)');
+    }
+    if (uri != null) {
+      buffer.write(' @ ${uri!.origin}${uri!.path}');
+    }
+    if (cause != null) {
+      buffer.write(' | cause: $cause');
+    }
+    return buffer.toString();
+  }
+}

--- a/lib/widgets/cart_bottom_sheet.dart
+++ b/lib/widgets/cart_bottom_sheet.dart
@@ -69,7 +69,7 @@ class CartBottomSheet extends StatelessWidget {
                       children: <Widget>[
                         Text('Subtotal', style: theme.textTheme.titleMedium),
                         Text(
-                          'USD ${cart.subtotal.toStringAsFixed(2)}',
+                          cart.formatAmount(cart.subtotal),
                           style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
                         ),
                       ],
@@ -157,7 +157,7 @@ class _CartItemRow extends StatelessWidget {
                     onIncrease: () => cart.addItem(item.product),
                   ),
                   Text(
-                    'USD ${(item.subtotal).toStringAsFixed(2)}',
+                    item.product.formatPrice(item.subtotal),
                     style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
                   ),
                 ],

--- a/lib/widgets/product_card.dart
+++ b/lib/widgets/product_card.dart
@@ -82,7 +82,7 @@ class ProductCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.end,
               children: <Widget>[
                 Text(
-                  'USD ${product.price.toStringAsFixed(2)}',
+                  product.formatPrice(product.price),
                   style: theme.textTheme.titleLarge?.copyWith(
                     color: colors.primary,
                     fontWeight: FontWeight.bold,
@@ -91,7 +91,7 @@ class ProductCard extends StatelessWidget {
                 if (product.oldPrice != null) ...<Widget>[
                   const SizedBox(width: 8),
                   Text(
-                    'USD ${product.oldPrice!.toStringAsFixed(2)}',
+                    product.formatPrice(product.oldPrice!),
                     style: theme.textTheme.bodyMedium?.copyWith(
                       color: colors.outline,
                       decoration: TextDecoration.lineThrough,


### PR DESCRIPTION
## Summary
- update store constants to include multiple WooCommerce base and checkout endpoints and refresh the README guidance
- refactor `StoreService` to probe each API candidate with timeouts, richer error context, and cleaner offline messaging
- enhance `OrderService` to try every configured checkout endpoint with request timeouts before falling back to the offline catalogue

## Testing
- not run (Flutter/Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c90600f7c88320b94644f254e22013